### PR TITLE
Enhance Frame Resilience for TCP Reads Against potential corruption caused by bulk TCP reads.

### DIFF
--- a/internal/protocol/frame_handler.go
+++ b/internal/protocol/frame_handler.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"io"
 	"net"
@@ -45,13 +44,31 @@ func NewJT808FrameHandler(conn net.Conn) *JT808FrameHandler {
 }
 
 func (fh *JT808FrameHandler) Recv(ctx context.Context) (FramePayload, error) {
-	buf := make([]byte, MaxFrameLen)
-	_, err := fh.rbuf.Read(buf)
-	if err != nil {
-		return nil, errors.Wrap(err, "Fail to read stream to framePayload")
+	var inMessage bool
+	buf := make([]byte, 0, MaxFrameLen)
+	readBuf := make([]byte, 1)
+	for {
+		// Read one byte from the connection
+		_, err := fh.rbuf.Read(readBuf)
+
+		if err != nil {
+			return nil, errors.Wrap(err, "Fail to read stream to framePayload")
+		}
+
+		if readBuf[0] == 0x7e {
+			buf = append(buf, readBuf[0])
+			if inMessage {
+				// end bit
+				break
+			}
+			// start bit
+			inMessage = !inMessage
+		} else {
+			if inMessage {
+				buf = append(buf, readBuf[0])
+			}
+		}
 	}
-	// 移除末尾多余的0
-	buf = bytes.TrimRight(buf, "\x00")
 
 	if len(buf) == 0 {
 		return nil, ErrFrameReadEmpty

--- a/internal/protocol/frame_handler_test.go
+++ b/internal/protocol/frame_handler_test.go
@@ -1,0 +1,149 @@
+package protocol
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/fakeyanss/jt808-server-go/internal/codec/hex"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJT808Frame_handler_recv(t *testing.T) {
+	type args struct {
+		payload []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    [][]byte
+		wantErr bool
+	}{
+		{
+			name: "2 packages, garbage at middle",
+			args: args{
+				payload: hex.Str2Byte("7e5622664455e2447e549955777e1122334455668899557e"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e5622664455e2447e"),
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "1 package, garbage at middle and last section",
+			args: args{
+				payload: hex.Str2Byte("7e5622664455e2447e549955777e112233445566889955"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e5622664455e2447e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 packages, garbage at first and last section",
+			args: args{
+				payload: hex.Str2Byte("55667e5622664455e2447e7e1122334455668899557e44"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e5622664455e2447e"),
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 packages, garbage at first section",
+			args: args{
+				payload: hex.Str2Byte("55667e5622664455e2447e7e1122334455668899557e"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e5622664455e2447e"),
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 packages, garbage at last section",
+			args: args{
+				payload: hex.Str2Byte("7e5622664455e2447e7e1122334455668899557e44"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e5622664455e2447e"),
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 packages",
+			args: args{
+				payload: hex.Str2Byte("7e5622664455e2447e7e1122334455668899557e"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e5622664455e2447e"),
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "1 package, garbage at first and last section",
+			args: args{
+				payload: hex.Str2Byte("557e1122334455668899557e44"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "1 package, garbage at first section",
+			args: args{
+				payload: hex.Str2Byte("55447e1122334455668899557e"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "1 package, garbage at last section",
+			args: args{
+				payload: hex.Str2Byte("7e1122334455668899557e44"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "1 package",
+			args: args{
+				payload: hex.Str2Byte("7e1122334455668899557e"),
+			},
+			want: [][]byte{
+				hex.Str2Byte("7e1122334455668899557e"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "0 package",
+			args: args{
+				payload: hex.Str2Byte("1122334455668899557e"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bytes.NewReader(tt.args.payload)
+			fh := &JT808FrameHandler{
+				rbuf: bufio.NewReader(reader),
+			}
+			for _, v := range tt.want {
+				fr, err := fh.Recv(context.Background())
+				require.Equal(t, tt.wantErr, err != nil, err)
+				require.Equal(t, FramePayload(v), fr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Refactored the code to improve the resilience of frames against potential corruption caused by bulk TCP reads.
* Introduced a loop for reading one byte at a time from the connection to ensure frame integrity.
* Implemented logic to identify the start and end bits of a frame, ensuring that frames are properly delineated and reconstructed.
* Add unit test